### PR TITLE
passing `GITHUB_TOKEN` to `Octokit`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ const getOctokit = (() => {
             return octokit;
         }
 
-        octokit = new Octokit();
+        const auth = process.env["GITHUB_TOKEN"];
+        octokit = new Octokit(auth ? { auth } : undefined);
 
         return getOctokit();
     };


### PR DESCRIPTION
Hi @garronej!

Thank you for the great product "denoify"! We always use it.

This PR enables passing `GITHUB_TOKEN` to `Octokit` to avoid API rate limit.

<img width="650" alt="Screenshot 2023-10-12 at 18 29 02" src="https://github.com/garronej/get-github-default-branch-name/assets/10682/914916cb-bab1-41cb-a21f-c3e87b42389d">

In the [denoify](https://github.com/garronej/denoify) package, it's enabled but, we need to set the env value also in this package.